### PR TITLE
validator-rewards: compute merkle tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "borsh 1.5.7",
  "futures",
  "mockall 0.13.1",
  "reqwest",
@@ -1502,6 +1503,7 @@ dependencies = [
  "solana-client",
  "solana-sdk",
  "solana-transaction-status-client-types",
+ "svm-hash",
  "tokio",
 ]
 

--- a/crates/validator-revenue/Cargo.toml
+++ b/crates/validator-revenue/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+borsh.workspace = true
 futures.workspace = true
 mockall.workspace = true
 reqwest.workspace = true
@@ -20,4 +21,5 @@ serde.workspace = true
 solana-client.workspace = true
 solana-sdk.workspace = true
 solana-transaction-status-client-types.workspace = true
+svm-hash.workspace = true
 tokio.workspace = true

--- a/crates/validator-revenue/src/lib.rs
+++ b/crates/validator-revenue/src/lib.rs
@@ -6,18 +6,78 @@
 //! - figure out if underlying reqwest lib in solana client be modified to not retry
 //! - benchmark expected number of validators for mainnet beta launch and 6 months after
 //! - handle DZ epochs once they're defined
-
 pub mod rewards;
-
 use anyhow::{anyhow, Result};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::Deserialize;
 use solana_client::rpc_config::{RpcBlockConfig, RpcGetVoteAccountsConfig};
-use solana_sdk::clock::DEFAULT_SLOTS_PER_EPOCH;
+use solana_sdk::{clock::DEFAULT_SLOTS_PER_EPOCH, pubkey::Pubkey};
 use std::collections::HashMap;
+use svm_hash::merkle::{merkle_root_from_byte_ref_leaves, MerkleProof};
 
 use crate::rewards::ValidatorRewards;
 
 const SLOT_TIME_DURATION_SECONDS: f64 = 0.4;
+
+#[derive(Debug, BorshDeserialize, BorshSerialize, Clone)]
+pub struct ComputedSolanaValidatorPayments {
+    pub epoch: u64,
+    pub payments: Vec<SolanaValidatorPayment>,
+}
+
+impl ComputedSolanaValidatorPayments {
+    pub fn find_payment_proof(
+        &self,
+        validator_id: &Pubkey,
+    ) -> Option<(&SolanaValidatorPayment, MerkleProof)> {
+        let index = self
+            .payments
+            .iter()
+            .position(|payment| &payment.node_id == validator_id)?;
+
+        let solana_validator_payment_entry = &self.payments[index];
+
+        let leaves = self.to_byte_leaves();
+
+        let proof = MerkleProof::from_byte_ref_leaves(
+            &leaves,
+            index,
+            Some(SolanaValidatorPayment::LEAF_PREFIX),
+        )?;
+        Some((solana_validator_payment_entry, proof))
+    }
+
+    pub fn merkle_root(&self) -> Option<svm_hash::sha2::Hash> {
+        let leaves = self.to_byte_leaves();
+        merkle_root_from_byte_ref_leaves(&leaves, Some(SolanaValidatorPayment::LEAF_PREFIX))
+    }
+
+    fn to_byte_leaves(&self) -> Vec<Vec<u8>> {
+        self.payments
+            .iter()
+            .map(|payment| borsh::to_vec(&payment).unwrap())
+            .collect()
+    }
+}
+
+#[derive(Debug, BorshDeserialize, BorshSerialize, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SolanaValidatorPayment {
+    pub node_id: Pubkey,
+    pub amount: u64,
+}
+
+impl SolanaValidatorPayment {
+    pub const LEAF_PREFIX: &'static [u8] = b"solana_validator_payment";
+
+    pub fn merkle_root(&self, proof: MerkleProof) -> svm_hash::sha2::Hash {
+        let mut leaf = [0; 40];
+
+        // This is infallible because we know the size of the struct.
+        borsh::to_writer(&mut leaf[..], &self).unwrap();
+
+        proof.root_from_leaf(&leaf, Some(Self::LEAF_PREFIX))
+    }
+}
 
 #[derive(Deserialize, Debug)]
 pub struct Reward {
@@ -137,6 +197,7 @@ fn epoch_from_timestamp(block_time: u64, current_slot: u64, timestamp: u64) -> R
 
 #[cfg(test)]
 mod tests {
+
     use crate::rewards::{JitoReward, JitoRewards, LAMPORT_MULTIPLE};
 
     use super::*;
@@ -453,5 +514,67 @@ mod tests {
             reward.block_base + reward.inflation + reward.jito
         );
         assert_eq!(reward.block_priority, block_reward - signatures);
+    }
+
+    #[test]
+    fn test_add_rewards_to_tree() -> Result<()> {
+        let payments = ComputedSolanaValidatorPayments {
+            epoch: 822,
+            payments: vec![
+                SolanaValidatorPayment {
+                    node_id: Pubkey::new_unique(),
+                    amount: 1343542456,
+                },
+                SolanaValidatorPayment {
+                    node_id: Pubkey::new_unique(),
+                    amount: 234234324,
+                },
+            ],
+        };
+
+        let leaf_prefix = Some(SolanaValidatorPayment::LEAF_PREFIX);
+        let leaves = payments.to_byte_leaves();
+        let leaves_ref: Vec<&[u8]> = leaves.iter().map(|v| v.as_slice()).collect();
+        let root = payments.merkle_root().unwrap();
+        dbg!(root);
+
+        let proof_left = payments
+            .find_payment_proof(&payments.payments[0].node_id)
+            .unwrap();
+
+        let computed_proof_left = proof_left
+            .1
+            .root_from_byte_ref_leaf(&leaves_ref[0], Some(SolanaValidatorPayment::LEAF_PREFIX));
+
+        let proof_right = payments
+            .find_payment_proof(&payments.payments[1].node_id)
+            .unwrap();
+
+        let computed_proof_right = proof_right
+            .1
+            .root_from_byte_ref_leaf(&leaves_ref[1], Some(SolanaValidatorPayment::LEAF_PREFIX));
+
+        assert_eq!(
+            proof_left.1.root_from_leaf(leaves_ref[0], leaf_prefix),
+            computed_proof_left
+        );
+        assert_eq!(
+            proof_left.1.root_from_leaf(leaves_ref[0], leaf_prefix),
+            root
+        );
+
+        assert_eq!(
+            proof_right.1.root_from_leaf(leaves_ref[1], leaf_prefix),
+            computed_proof_right
+        );
+        assert_eq!(
+            proof_right.1.root_from_leaf(leaves_ref[1], leaf_prefix),
+            root
+        );
+
+        assert_eq!(proof_left.0.node_id, payments.payments[0].node_id);
+        assert_eq!(proof_right.0.node_id, payments.payments[1].node_id);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary of Changes

This PR adds the beginnings of adding a merkle tree which contains leaves of validators ids and rewards for particular epoch.

Closes https://github.com/malbeclabs/doublezero/issues/767.

## Testing Verification

* Adds a simple test that verifies that a proof and leaf equal the expected merkle root