### PR TITLE
Fixup contributor revenue storage

### DIFF
--- a/crates/contributor-rewards/src/calculator/proof.rs
+++ b/crates/contributor-rewards/src/calculator/proof.rs
@@ -1,6 +1,8 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use borsh::{BorshDeserialize, BorshSerialize};
 use network_shapley::shapley::ShapleyOutput;
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
 use svm_hash::{
     merkle::{merkle_root_from_byte_ref_leaves, MerkleProof},
     sha2::Hash,
@@ -8,11 +10,15 @@ use svm_hash::{
 
 const LEAF_PREFIX: &[u8] = b"dz_contributor_rewards";
 
+/// Represents a contributor's reward with Pubkey and u32 proportion (9-decimal precision)
+/// where 1_000_000_000 = 100%
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
 pub struct ContributorRewardDetail {
-    pub operator: String,
-    pub value: f64,
-    pub proportion: f64,
+    // contributor.owner
+    pub contributor_key: Pubkey,
+    // 9-decimal proportion (1_000_000_000 = 100%)
+    pub proportion: u32,
+    // TODO: Add is_claimable: bool in future PR
 }
 
 impl ContributorRewardDetail {
@@ -26,13 +32,13 @@ pub struct ContributorRewardsMerkleRoot {
     pub total_contributors: u32,
 }
 
+/// Storage structure for consolidated shapley output
+/// This is what gets stored on-chain instead of individual proofs
 #[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
-pub struct ContributorRewardProof {
+pub struct ShapleyOutputStorage {
     pub epoch: u64,
-    pub contributor: String,
-    pub reward: ContributorRewardDetail,
-    pub proof_bytes: Vec<u8>, // Store serialized MerkleProof
-    pub index: u32,
+    pub rewards: Vec<ContributorRewardDetail>,
+    pub total_proportions: u32, // Should equal 1_000_000_000 for validation
 }
 
 #[derive(Debug)]
@@ -44,14 +50,31 @@ pub struct ContributorRewardsMerkleTree {
 
 impl ContributorRewardsMerkleTree {
     pub fn new(epoch: u64, shapley_output: &ShapleyOutput) -> Result<Self> {
-        let rewards: Vec<ContributorRewardDetail> = shapley_output
-            .iter()
-            .map(|(operator, val)| ContributorRewardDetail {
-                operator: operator.to_string(),
-                value: val.value,
-                proportion: val.proportion,
-            })
-            .collect();
+        let mut rewards = Vec::new();
+        let mut total_proportions: u32 = 0;
+
+        for (operator_pubkey_str, val) in shapley_output.iter() {
+            // Parse the operator string as a Pubkey
+            let contributor_key = Pubkey::from_str(operator_pubkey_str)
+                .map_err(|e| anyhow!("Invalid pubkey string '{}': {}", operator_pubkey_str, e))?;
+
+            // Convert f64 proportion to u32 with 9 decimal places
+            let proportion = (val.proportion * 1_000_000_000.0).round() as u32;
+            total_proportions = total_proportions.saturating_add(proportion);
+
+            rewards.push(ContributorRewardDetail {
+                contributor_key,
+                proportion,
+            });
+        }
+
+        // Validate that proportions sum to approximately 1_000_000_000 (allowing small rounding errors)
+        if !(999_999_000..=1_000_001_000).contains(&total_proportions) {
+            bail!(
+                "Total proportions {} not equal to 1_000_000_000 (±0.0001%)",
+                total_proportions
+            );
+        }
 
         let leaves: Vec<Vec<u8>> = rewards
             .iter()
@@ -119,26 +142,55 @@ impl ContributorRewardsMerkleTree {
     }
 }
 
-// Convenience functions for direct usage
-pub fn compute_rewards_merkle_root(epoch: u64, shapley_output: &ShapleyOutput) -> Result<Hash> {
-    let tree = ContributorRewardsMerkleTree::new(epoch, shapley_output)?;
-    tree.compute_root()
+/// Generate a merkle proof dynamically from stored shapley output
+pub fn generate_proof_from_shapley(
+    shapley_storage: &ShapleyOutputStorage,
+    contributor_pubkey: &Pubkey,
+) -> Result<(MerkleProof, ContributorRewardDetail, Hash)> {
+    // Find the contributor in the rewards list
+    let mut contributor_index = None;
+    let mut contributor_reward = None;
+
+    for (index, reward) in shapley_storage.rewards.iter().enumerate() {
+        if reward.contributor_key == *contributor_pubkey {
+            contributor_index = Some(index);
+            contributor_reward = Some(reward.clone());
+            break;
+        }
+    }
+
+    let index = contributor_index.ok_or_else(|| {
+        anyhow!(
+            "Contributor {} not found in shapley output",
+            contributor_pubkey
+        )
+    })?;
+    let reward = contributor_reward.unwrap();
+
+    // Reconstruct the merkle tree from the stored rewards
+    let leaves: Vec<Vec<u8>> = shapley_storage
+        .rewards
+        .iter()
+        .map(|r| borsh::to_vec(r).map_err(|e| anyhow!("Failed to serialize reward: {}", e)))
+        .collect::<Result<Vec<_>>>()?;
+
+    // Generate the proof
+    let proof =
+        MerkleProof::from_byte_ref_leaves(&leaves, index, Some(LEAF_PREFIX)).ok_or_else(|| {
+            anyhow!(
+                "Failed to generate proof for contributor at index {}",
+                index
+            )
+        })?;
+
+    // Compute the root for verification
+    let root = merkle_root_from_byte_ref_leaves(&leaves, Some(LEAF_PREFIX))
+        .ok_or_else(|| anyhow!("Failed to compute merkle root"))?;
+
+    Ok((proof, reward, root))
 }
 
-pub fn generate_rewards_proof(
-    epoch: u64,
-    shapley_output: &ShapleyOutput,
-    contributor_index: usize,
-) -> Result<(MerkleProof, ContributorRewardDetail)> {
-    let tree = ContributorRewardsMerkleTree::new(epoch, shapley_output)?;
-    let proof = tree.generate_proof(contributor_index)?;
-    let reward = tree
-        .get_reward(contributor_index)
-        .ok_or_else(|| anyhow!("Reward not found at index {}", contributor_index))?
-        .clone();
-
-    Ok((proof, reward))
-}
+// Deprecated functions have been removed - use generate_proof_from_shapley instead
 
 #[cfg(test)]
 mod tests {
@@ -148,21 +200,21 @@ mod tests {
     fn create_test_shapley_output() -> ShapleyOutput {
         let mut output = ShapleyOutput::new();
         output.insert(
-            "Alice".to_string(),
+            "11111111111111111111111111111112".to_string(), // Alice pubkey
             ShapleyValue {
                 value: 100.0,
                 proportion: 0.5,
             },
         );
         output.insert(
-            "Bob".to_string(),
+            "11111111111111111111111111111113".to_string(), // Bob pubkey
             ShapleyValue {
                 value: 50.0,
                 proportion: 0.25,
             },
         );
         output.insert(
-            "Charlie".to_string(),
+            "11111111111111111111111111111114".to_string(), // Charlie pubkey
             ShapleyValue {
                 value: 50.0,
                 proportion: 0.25,
@@ -174,7 +226,7 @@ mod tests {
     fn create_single_contributor_output() -> ShapleyOutput {
         let mut output = ShapleyOutput::new();
         output.insert(
-            "Solo".to_string(),
+            "11111111111111111111111111111115".to_string(), // Solo pubkey
             ShapleyValue {
                 value: 200.0,
                 proportion: 1.0,
@@ -200,14 +252,20 @@ mod tests {
         let rewards = tree.rewards();
         assert_eq!(rewards.len(), 3);
 
-        // Find each contributor in rewards (order may vary due to HashMap)
-        let alice = rewards.iter().find(|r| r.operator == "Alice").unwrap();
-        assert_eq!(alice.value, 100.0);
-        assert_eq!(alice.proportion, 0.5);
+        // Find each contributor in rewards by their pubkey
+        let alice_pubkey = Pubkey::from_str("11111111111111111111111111111112").unwrap();
+        let alice = rewards
+            .iter()
+            .find(|r| r.contributor_key == alice_pubkey)
+            .unwrap();
+        assert_eq!(alice.proportion, 500_000_000); // 0.5 * 1_000_000_000
 
-        let bob = rewards.iter().find(|r| r.operator == "Bob").unwrap();
-        assert_eq!(bob.value, 50.0);
-        assert_eq!(bob.proportion, 0.25);
+        let bob_pubkey = Pubkey::from_str("11111111111111111111111111111113").unwrap();
+        let bob = rewards
+            .iter()
+            .find(|r| r.contributor_key == bob_pubkey)
+            .unwrap();
+        assert_eq!(bob.proportion, 250_000_000); // 0.25 * 1_000_000_000
     }
 
     #[test]
@@ -235,18 +293,13 @@ mod tests {
     #[test]
     fn test_empty_tree() {
         let output = create_empty_output();
-        let tree = ContributorRewardsMerkleTree::new(789, &output).unwrap();
-
-        assert_eq!(tree.len(), 0);
-        assert!(tree.is_empty());
-
-        // Empty tree cannot compute a root (returns error)
-        let result = tree.compute_root();
+        // Empty tree will fail validation because proportions sum to 0, not 1_000_000_000
+        let result = ContributorRewardsMerkleTree::new(789, &output);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Failed to compute merkle root"));
+            .contains("Total proportions"))
     }
 
     #[test]
@@ -325,49 +378,35 @@ mod tests {
     }
 
     #[test]
-    fn test_contributor_reward_proof_struct() {
+    fn test_generate_proof_from_shapley() {
         let output = create_test_shapley_output();
-        let tree = ContributorRewardsMerkleTree::new(500, &output).unwrap();
+        let tree = ContributorRewardsMerkleTree::new(600, &output).unwrap();
 
-        let proof = tree.generate_proof(0).unwrap();
-        let reward = tree.get_reward(0).unwrap().clone();
-        let proof_bytes = borsh::to_vec(&proof).unwrap();
-
-        // Create ContributorRewardProof
-        let contributor_proof = ContributorRewardProof {
-            epoch: 500,
-            contributor: reward.operator.clone(),
-            reward: reward.clone(),
-            proof_bytes,
-            index: 0,
+        // Create ShapleyOutputStorage
+        let shapley_storage = ShapleyOutputStorage {
+            epoch: 600,
+            rewards: tree.rewards().to_vec(),
+            total_proportions: tree.rewards().iter().map(|r| r.proportion).sum(),
         };
 
-        // Serialize and deserialize
-        let serialized = borsh::to_vec(&contributor_proof).unwrap();
-        let deserialized: ContributorRewardProof = borsh::from_slice(&serialized).unwrap();
+        // Test generating proof for Alice
+        let alice_pubkey = Pubkey::from_str("11111111111111111111111111111112").unwrap();
+        let (proof, reward, root) =
+            generate_proof_from_shapley(&shapley_storage, &alice_pubkey).unwrap();
 
-        assert_eq!(deserialized.epoch, 500);
-        assert_eq!(deserialized.contributor, reward.operator);
-        assert_eq!(deserialized.reward.value, reward.value);
-        assert_eq!(deserialized.reward.proportion, reward.proportion);
-        assert_eq!(deserialized.index, 0);
-    }
-
-    #[test]
-    fn test_convenience_functions() {
-        let output = create_test_shapley_output();
-
-        // Test compute_rewards_merkle_root
-        let root = compute_rewards_merkle_root(600, &output).unwrap();
-        assert_ne!(root, Hash::default());
-
-        // Test generate_rewards_proof
-        let (proof, reward) = generate_rewards_proof(600, &output, 0).unwrap();
+        assert_eq!(reward.contributor_key, alice_pubkey);
+        assert_eq!(reward.proportion, 500_000_000); // 0.5 * 1_000_000_000
 
         // Verify the proof
         let leaf = borsh::to_vec(&reward).unwrap();
         let computed_root = proof.root_from_leaf(&leaf, Some(LEAF_PREFIX));
         assert_eq!(computed_root, root);
+
+        // Test for non-existent contributor
+        let fake_pubkey = Pubkey::from_str("11111111111111111111111111111199").unwrap();
+        let result = generate_proof_from_shapley(&shapley_storage, &fake_pubkey);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
     }
 
     #[test]
@@ -394,8 +433,8 @@ mod tests {
         let proof = tree.generate_proof(0).unwrap();
         let mut reward = tree.get_reward(0).unwrap().clone();
 
-        // Modify reward
-        reward.value += 1.0;
+        // Modify reward proportion
+        reward.proportion += 1;
 
         // Verify modified reward doesn't validate
         let leaf = borsh::to_vec(&reward).unwrap();
@@ -408,10 +447,15 @@ mod tests {
     fn test_merkle_root_with_many_contributors() {
         let mut output = ShapleyOutput::new();
 
-        // Create 100 contributors
+        // Create 100 contributors using deterministic pubkeys
         for i in 0..100 {
+            // Generate a deterministic pubkey for each contributor
+            let mut bytes = [0u8; 32];
+            bytes[0] = i as u8;
+            bytes[1] = (i >> 8) as u8;
+            let pubkey = Pubkey::new_from_array(bytes);
             output.insert(
-                format!("Contributor{i}"),
+                pubkey.to_string(),
                 ShapleyValue {
                     value: (i as f64) * 10.0,
                     proportion: (i as f64) / 4950.0, // Sum of 0..100 = 4950
@@ -442,14 +486,14 @@ mod tests {
     fn test_zero_value_rewards() {
         let mut output = ShapleyOutput::new();
         output.insert(
-            "Zero".to_string(),
+            "11111111111111111111111111111116".to_string(), // Zero pubkey
             ShapleyValue {
                 value: 0.0,
                 proportion: 0.0,
             },
         );
         output.insert(
-            "NonZero".to_string(),
+            "11111111111111111111111111111117".to_string(), // NonZero pubkey
             ShapleyValue {
                 value: 100.0,
                 proportion: 1.0,
@@ -474,14 +518,14 @@ mod tests {
     fn test_negative_value_rewards() {
         let mut output = ShapleyOutput::new();
         output.insert(
-            "Negative".to_string(),
+            "11111111111111111111111111111118".to_string(), // Negative pubkey
             ShapleyValue {
                 value: -50.0,
                 proportion: -0.5,
             },
         );
         output.insert(
-            "Positive".to_string(),
+            "11111111111111111111111111111119".to_string(), // Positive pubkey
             ShapleyValue {
                 value: 100.0,
                 proportion: 1.0,

--- a/crates/contributor-rewards/src/calculator/shapley_handler.rs
+++ b/crates/contributor-rewards/src/calculator/shapley_handler.rs
@@ -31,7 +31,8 @@ pub fn build_devices(fetch_data: &FetchData) -> Result<Devices> {
             devices.push(Device {
                 device: device.code.clone(),
                 edge: DEFAULT_EDGE_BANDWIDTH_GBPS,
-                operator: contributor.code.to_string(), // For now just use code
+                // Use owner pubkey as operator ID
+                operator: contributor.owner.to_string(),
             });
         }
     }


### PR DESCRIPTION
Summary
----

- Replace individual proof storage (N accounts) with single ShapleyOutputStorage
- Update ContributorRewardDetail to use Pubkey and u32 proportion (9-decimal precision)
- Implement dynamic proof generation via generate_proof_from_shapley()
- Use contributor.owner as operator ID for proper pubkey mapping
- Remove deprecated functions and update test suite