### PR TITLE
revenue-distribution: block setting a new rewards manager

### DIFF
--- a/programs/revenue-distribution/src/instruction/mod.rs
+++ b/programs/revenue-distribution/src/instruction/mod.rs
@@ -57,6 +57,7 @@ pub enum ProgramFlagConfiguration {
 #[derive(Debug, BorshDeserialize, BorshSerialize, Clone, PartialEq, Eq)]
 pub enum ContributorRewardsConfiguration {
     Recipients(Vec<(Pubkey, u16)>),
+    IsSetRewardsManagerBlocked(bool),
 }
 
 #[derive(Debug, BorshDeserialize, BorshSerialize, Clone, PartialEq, Eq)]

--- a/programs/revenue-distribution/src/state/contributor_rewards/mod.rs
+++ b/programs/revenue-distribution/src/state/contributor_rewards/mod.rs
@@ -33,8 +33,20 @@ impl PrecomputedDiscriminator for ContributorRewards {
 impl ContributorRewards {
     pub const SEED_PREFIX: &'static [u8] = b"contributor_rewards";
 
+    pub const FLAG_IS_SET_REWARDS_MANAGER_BLOCKED_BIT: usize = 0;
+
     pub fn find_address(service_key: &Pubkey) -> (Pubkey, u8) {
         Pubkey::find_program_address(&[Self::SEED_PREFIX, service_key.as_ref()], &crate::ID)
+    }
+
+    pub fn is_set_rewards_manager_blocked(&self) -> bool {
+        self.flags
+            .bit(Self::FLAG_IS_SET_REWARDS_MANAGER_BLOCKED_BIT)
+    }
+
+    pub fn set_is_set_rewards_manager_blocked(&mut self, should_block: bool) {
+        self.flags
+            .set_bit(Self::FLAG_IS_SET_REWARDS_MANAGER_BLOCKED_BIT, should_block);
     }
 }
 

--- a/programs/revenue-distribution/tests/configure_contributor_rewards_test.rs
+++ b/programs/revenue-distribution/tests/configure_contributor_rewards_test.rs
@@ -69,9 +69,10 @@ async fn test_initialize_contributor_rewards() {
         .configure_contributor_rewards(
             &service_key,
             &rewards_manager_signer,
-            [ContributorRewardsConfiguration::Recipients(
-                recipients.to_vec(),
-            )],
+            [
+                ContributorRewardsConfiguration::Recipients(recipients.to_vec()),
+                ContributorRewardsConfiguration::IsSetRewardsManagerBlocked(true),
+            ],
         )
         .await
         .unwrap();
@@ -79,6 +80,7 @@ async fn test_initialize_contributor_rewards() {
     let (_, contributor_rewards) = test_setup.fetch_contributor_rewards(&service_key).await;
 
     let mut expected_contributor_rewards = ContributorRewards::default();
+    expected_contributor_rewards.set_is_set_rewards_manager_blocked(true);
     expected_contributor_rewards.service_key = service_key;
     expected_contributor_rewards.rewards_manager_key = rewards_manager_signer.pubkey();
     expected_contributor_rewards.recipient_shares = RecipientShares::new(&recipients).unwrap();

--- a/programs/revenue-distribution/tests/set_rewards_manager_test.rs
+++ b/programs/revenue-distribution/tests/set_rewards_manager_test.rs
@@ -2,13 +2,22 @@ mod common;
 
 //
 
+use doublezero_program_tools::instruction::try_build_instruction;
 use doublezero_revenue_distribution::{
-    instruction::{ProgramConfiguration, ProgramFlagConfiguration},
+    instruction::{
+        account::SetRewardsManagerAccounts, ContributorRewardsConfiguration, ProgramConfiguration,
+        ProgramFlagConfiguration, RevenueDistributionInstructionData,
+    },
     state::ContributorRewards,
+    ID,
 };
 use solana_program_test::tokio;
 use solana_pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, Signer};
+use solana_sdk::{
+    instruction::InstructionError,
+    signature::{Keypair, Signer},
+    transaction::TransactionError,
+};
 
 //
 // Set rewards manager.
@@ -49,7 +58,8 @@ async fn test_set_rewards_manager() {
 
     // Test input.
 
-    let rewards_manager_key = Pubkey::new_unique();
+    let rewards_manager_signer = Keypair::new();
+    let rewards_manager_key = rewards_manager_signer.pubkey();
 
     test_setup
         .set_rewards_manager(
@@ -66,4 +76,53 @@ async fn test_set_rewards_manager() {
     expected_contributor_rewards.service_key = service_key;
     expected_contributor_rewards.rewards_manager_key = rewards_manager_key;
     assert_eq!(contributor_rewards, expected_contributor_rewards);
+
+    // Cannot set rewards manager if it is blocked.
+
+    test_setup
+        .configure_contributor_rewards(
+            &service_key,
+            &rewards_manager_signer,
+            [ContributorRewardsConfiguration::IsSetRewardsManagerBlocked(
+                true,
+            )],
+        )
+        .await
+        .unwrap();
+
+    let set_rewards_manager_ix = try_build_instruction(
+        &ID,
+        SetRewardsManagerAccounts::new(&contributor_manager_signer.pubkey(), &service_key),
+        &RevenueDistributionInstructionData::SetRewardsManager(Pubkey::new_unique()),
+    )
+    .unwrap();
+
+    let (tx_err, program_logs) = test_setup
+        .unwrap_simulation_error(&[set_rewards_manager_ix], &[&contributor_manager_signer])
+        .await;
+    assert_eq!(
+        tx_err,
+        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
+    );
+    assert_eq!(program_logs.get(2).unwrap(), "Program log: Blocked");
+
+    // Can set after unblocking.
+
+    test_setup
+        .configure_contributor_rewards(
+            &service_key,
+            &rewards_manager_signer,
+            [ContributorRewardsConfiguration::IsSetRewardsManagerBlocked(
+                false,
+            )],
+        )
+        .await
+        .unwrap()
+        .set_rewards_manager(
+            &service_key,
+            &contributor_manager_signer,
+            &rewards_manager_key,
+        )
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
Opt out of the contributor manager from setting a new rewards manager by blocking the set-rewards-manager instruction.

Contributors may not want the contributor manager to have this level of control. But the rewards manager has the option to opt into allowing the contributor manager again.

Closes https://github.com/malbeclabs/doublezero/issues/1348.