### PR TITLE
revenue-distribution: enforce grace period after initializing distribution

### DIFF
--- a/programs/revenue-distribution/src/state/distribution.rs
+++ b/programs/revenue-distribution/src/state/distribution.rs
@@ -75,8 +75,12 @@ pub struct Distribution {
     pub processed_rewards_start_index: u32,
     pub processed_rewards_end_index: u32,
 
+    /// Distribute rewards relay lamports copied from the program config.
     pub distribute_rewards_relay_lamports: u32,
-    _padding_1: [u32; 1],
+
+    /// The timestamp when the distribution account is allowed to accept
+    /// calculations.
+    pub calculation_allowed_timestamp: u32,
 
     pub distributed_2z_amount: u64,
     pub burned_2z_amount: u64,
@@ -170,6 +174,17 @@ impl Distribution {
         let burn_share_amount = burn_rate.mul_scalar(share_amount);
 
         Some((burn_share_amount, share_amount - burn_share_amount))
+    }
+
+    #[inline]
+    pub fn checked_calculation_allowed_timestamp(&self) -> Option<i64> {
+        let allowed_timestamp = self.calculation_allowed_timestamp;
+
+        if allowed_timestamp == 0 {
+            None
+        } else {
+            Some(i64::from(allowed_timestamp))
+        }
     }
 }
 

--- a/programs/revenue-distribution/src/state/program_config/mod.rs
+++ b/programs/revenue-distribution/src/state/program_config/mod.rs
@@ -192,6 +192,18 @@ impl ProgramConfig {
             Some(duration.into())
         }
     }
+
+    pub fn checked_calculation_grace_period_seconds(&self) -> Option<u32> {
+        let grace_period = self
+            .distribution_parameters
+            .calculation_grace_period_seconds;
+
+        if grace_period == 0 {
+            None
+        } else {
+            Some(grace_period)
+        }
+    }
 }
 
 //

--- a/programs/revenue-distribution/tests/configure_distribution_debt_test.rs
+++ b/programs/revenue-distribution/tests/configure_distribution_debt_test.rs
@@ -35,6 +35,8 @@ async fn test_configure_distribution_debt() {
     // Relay settings.
     let distribute_rewards_relay_lamports = 10_000;
 
+    let calculation_grace_period_seconds = 3_600;
+
     test_setup
         .initialize_program()
         .await
@@ -67,6 +69,9 @@ async fn test_configure_distribution_debt() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(
+                    calculation_grace_period_seconds,
+                ),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -76,6 +81,9 @@ async fn test_configure_distribution_debt() {
         .await
         .unwrap()
         .initialize_distribution(&debt_accountant_signer)
+        .await
+        .unwrap()
+        .warp_timestamp_by(calculation_grace_period_seconds)
         .await
         .unwrap();
 
@@ -132,5 +140,7 @@ async fn test_configure_distribution_debt() {
     expected_distribution.total_solana_validator_debt = total_solana_validator_debt;
     expected_distribution.solana_validator_debt_merkle_root = solana_validator_debt_merkle_root;
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp =
+        test_setup.get_clock().await.unix_timestamp as u32;
     assert_eq!(distribution, expected_distribution);
 }

--- a/programs/revenue-distribution/tests/configure_distribution_rewards_test.rs
+++ b/programs/revenue-distribution/tests/configure_distribution_rewards_test.rs
@@ -66,6 +66,7 @@ async fn test_configure_distribution_rewards() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(1),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -75,6 +76,9 @@ async fn test_configure_distribution_rewards() {
         .await
         .unwrap()
         .initialize_distribution(&debt_accountant_signer)
+        .await
+        .unwrap()
+        .warp_timestamp_by(1)
         .await
         .unwrap();
 
@@ -110,5 +114,7 @@ async fn test_configure_distribution_rewards() {
     expected_distribution.total_contributors = total_contributors;
     expected_distribution.rewards_merkle_root = rewards_merkle_root;
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp =
+        test_setup.get_clock().await.unix_timestamp as u32;
     assert_eq!(distribution, expected_distribution);
 }

--- a/programs/revenue-distribution/tests/configure_journal_test.rs
+++ b/programs/revenue-distribution/tests/configure_journal_test.rs
@@ -53,6 +53,7 @@ async fn test_configure_journal() {
 
     let journal_key = Journal::find_address().0;
     let journal_account_data = test_setup
+        .context
         .banks_client
         .get_account(journal_key)
         .await
@@ -78,6 +79,7 @@ async fn test_configure_journal() {
     assert!(epoch_payments.0.is_empty());
 
     let custodied_2z_token_account_data = test_setup
+        .context
         .banks_client
         .get_account(state::find_2z_token_pda_address(&journal_key).0)
         .await

--- a/programs/revenue-distribution/tests/deny_prepaid_connection_access_test.rs
+++ b/programs/revenue-distribution/tests/deny_prepaid_connection_access_test.rs
@@ -86,6 +86,7 @@ async fn test_deny_prepaid_connection_access() {
     // No test inputs.
 
     let sentinel_balance_before = test_setup
+        .context
         .banks_client
         .get_balance(dz_ledger_sentinel_signer.pubkey())
         .await
@@ -102,6 +103,7 @@ async fn test_deny_prepaid_connection_access() {
 
     let (prepaid_connection_key, _) = PrepaidConnection::find_address(&user_key);
     let prepaid_connection_info = test_setup
+        .context
         .banks_client
         .get_account(prepaid_connection_key)
         .await
@@ -109,6 +111,7 @@ async fn test_deny_prepaid_connection_access() {
     assert!(prepaid_connection_info.is_none());
 
     let sentinel_balance_after = test_setup
+        .context
         .banks_client
         .get_balance(dz_ledger_sentinel_signer.pubkey())
         .await

--- a/programs/revenue-distribution/tests/forgive_solana_validator_debt_test.rs
+++ b/programs/revenue-distribution/tests/forgive_solana_validator_debt_test.rs
@@ -94,6 +94,7 @@ async fn test_forgive_solana_validator_debt() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(1),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -106,6 +107,9 @@ async fn test_forgive_solana_validator_debt() {
         .await
         .unwrap()
         .initialize_distribution(&debt_accountant_signer)
+        .await
+        .unwrap()
+        .warp_timestamp_by(1)
         .await
         .unwrap()
         .configure_distribution_debt(
@@ -301,6 +305,8 @@ async fn test_forgive_solana_validator_debt() {
     expected_distribution.collected_solana_validator_payments = paid_debt.amount;
     expected_distribution.processed_solana_validator_debt_end_index = total_solana_validators / 8;
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp =
+        test_setup.get_clock().await.unix_timestamp as u32;
     assert_eq!(distribution, expected_distribution);
 
     assert_eq!(remaining_distribution_data, vec![0b11111111, 0b11111111]);
@@ -325,6 +331,8 @@ async fn test_forgive_solana_validator_debt() {
     expected_distribution.uncollectible_sol_debt = total_solana_validator_debt - paid_debt.amount;
     expected_distribution.processed_solana_validator_debt_end_index = total_solana_validators / 8;
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp =
+        test_setup.get_clock().await.unix_timestamp as u32;
     assert_eq!(distribution, expected_distribution);
 
     assert_eq!(remaining_distribution_data, vec![0, 0]);

--- a/programs/revenue-distribution/tests/initialize_distribution_test.rs
+++ b/programs/revenue-distribution/tests/initialize_distribution_test.rs
@@ -23,6 +23,7 @@ async fn test_initialize_distribution() {
 
     let debt_accountant_signer = Keypair::new();
     let solana_validator_base_block_rewards_pct_fee = 500; // 5%.
+    let calculation_grace_period_seconds = 69;
 
     // Relay settings.
     let distribute_rewards_relay_lamports = 10_000;
@@ -64,6 +65,9 @@ async fn test_initialize_distribution() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(
+                    calculation_grace_period_seconds,
+                ),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -104,6 +108,12 @@ async fn test_initialize_distribution() {
         .base_block_rewards_pct =
         ValidatorFee::new(solana_validator_base_block_rewards_pct_fee).unwrap();
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp = test_setup
+        .get_clock()
+        .await
+        .unix_timestamp
+        .saturating_add(calculation_grace_period_seconds.into())
+        as u32;
     assert_eq!(distribution, expected_distribution);
     assert_eq!(distribution_custody.amount, 0);
 
@@ -118,6 +128,8 @@ async fn test_initialize_distribution() {
     expected_program_config.debt_accountant_key = debt_accountant_signer.pubkey();
 
     let expected_distribution_params = &mut expected_program_config.distribution_parameters;
+    expected_distribution_params.calculation_grace_period_seconds =
+        calculation_grace_period_seconds;
     expected_distribution_params
         .solana_validator_fee_parameters
         .base_block_rewards_pct =
@@ -158,6 +170,12 @@ async fn test_initialize_distribution() {
         .base_block_rewards_pct =
         ValidatorFee::new(solana_validator_base_block_rewards_pct_fee).unwrap();
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp = test_setup
+        .get_clock()
+        .await
+        .unix_timestamp
+        .saturating_add(calculation_grace_period_seconds.into())
+        as u32;
     assert_eq!(distribution, expected_distribution);
     assert_eq!(distribution_custody.amount, 0);
 
@@ -172,6 +190,8 @@ async fn test_initialize_distribution() {
     expected_program_config.debt_accountant_key = debt_accountant_signer.pubkey();
 
     let expected_distribution_params = &mut expected_program_config.distribution_parameters;
+    expected_distribution_params.calculation_grace_period_seconds =
+        calculation_grace_period_seconds;
     expected_distribution_params
         .solana_validator_fee_parameters
         .base_block_rewards_pct =

--- a/programs/revenue-distribution/tests/initialize_journal_test.rs
+++ b/programs/revenue-distribution/tests/initialize_journal_test.rs
@@ -23,6 +23,7 @@ async fn test_initialize_journal() {
 
     let journal_key = Journal::find_address().0;
     let journal_account_data = test_setup
+        .context
         .banks_client
         .get_account(journal_key)
         .await
@@ -44,6 +45,7 @@ async fn test_initialize_journal() {
     assert!(epoch_payments.0.is_empty());
 
     let custodied_2z_token_account_data = test_setup
+        .context
         .banks_client
         .get_account(state::find_2z_token_pda_address(&journal_key).0)
         .await

--- a/programs/revenue-distribution/tests/initialize_prepaid_connection_test.rs
+++ b/programs/revenue-distribution/tests/initialize_prepaid_connection_test.rs
@@ -101,7 +101,7 @@ async fn test_initialize_prepaid_connection() {
 
     let mut expected_prepaid_connection = PrepaidConnection::default();
     expected_prepaid_connection.user_key = user_key;
-    expected_prepaid_connection.termination_beneficiary_key = test_setup.payer_signer.pubkey();
+    expected_prepaid_connection.termination_beneficiary_key = test_setup.payer_signer().pubkey();
     expected_prepaid_connection.activation_cost = expected_activation_cost;
     expected_prepaid_connection.activation_funder_key = src_token_account_key;
     assert_eq!(prepaid_connection, expected_prepaid_connection);

--- a/programs/revenue-distribution/tests/initialize_program_test.rs
+++ b/programs/revenue-distribution/tests/initialize_program_test.rs
@@ -15,6 +15,7 @@ async fn test_initialize_program() {
     let (program_config_key, program_config_bump) = ProgramConfig::find_address();
 
     let program_config_account_data = test_setup
+        .context
         .banks_client
         .get_account(program_config_key)
         .await

--- a/programs/revenue-distribution/tests/initialize_swap_destination_test.rs
+++ b/programs/revenue-distribution/tests/initialize_swap_destination_test.rs
@@ -30,6 +30,7 @@ async fn test_initialize_swap_destination() {
     let (swap_destination_key, swap_dst_2z_token_pda_bump) =
         find_2z_token_pda_address(&swap_authority_key);
     let swap_destination_account_data = test_setup
+        .context
         .banks_client
         .get_account(swap_destination_key)
         .await

--- a/programs/revenue-distribution/tests/load_prepaid_connection_test.rs
+++ b/programs/revenue-distribution/tests/load_prepaid_connection_test.rs
@@ -177,7 +177,7 @@ async fn test_load_prepaid_connection() {
     expected_prepaid_connection_1.set_has_access_granted(true);
     expected_prepaid_connection_1.set_has_paid(true);
     expected_prepaid_connection_1.valid_through_dz_epoch = valid_through_dz_epoch;
-    expected_prepaid_connection_1.termination_beneficiary_key = test_setup.payer_signer.pubkey();
+    expected_prepaid_connection_1.termination_beneficiary_key = test_setup.payer_signer().pubkey();
     expected_prepaid_connection_1.activation_cost = expected_activation_cost;
     expected_prepaid_connection_1.activation_funder_key = src_token_account_key;
     assert_eq!(prepaid_connection, expected_prepaid_connection_1);
@@ -338,7 +338,7 @@ async fn test_load_prepaid_connection() {
     expected_prepaid_connection_2.set_has_access_granted(true);
     expected_prepaid_connection_2.set_has_paid(true);
     expected_prepaid_connection_2.valid_through_dz_epoch = valid_through_dz_epoch;
-    expected_prepaid_connection_2.termination_beneficiary_key = test_setup.payer_signer.pubkey();
+    expected_prepaid_connection_2.termination_beneficiary_key = test_setup.payer_signer().pubkey();
     expected_prepaid_connection_2.activation_cost = expected_activation_cost;
     expected_prepaid_connection_2.activation_funder_key = src_token_account_key;
     assert_eq!(prepaid_connection, expected_prepaid_connection_2);
@@ -426,6 +426,7 @@ async fn test_load_prepaid_connection() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(1),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -532,7 +533,7 @@ async fn test_load_prepaid_connection() {
     expected_prepaid_connection_3.set_has_access_granted(true);
     expected_prepaid_connection_3.set_has_paid(true);
     expected_prepaid_connection_3.valid_through_dz_epoch = valid_through_dz_epoch;
-    expected_prepaid_connection_3.termination_beneficiary_key = test_setup.payer_signer.pubkey();
+    expected_prepaid_connection_3.termination_beneficiary_key = test_setup.payer_signer().pubkey();
     expected_prepaid_connection_3.activation_cost = expected_activation_cost;
     expected_prepaid_connection_3.activation_funder_key = src_token_account_key;
     assert_eq!(prepaid_connection, expected_prepaid_connection_3);

--- a/programs/revenue-distribution/tests/sweep_distribution_tokens_test.rs
+++ b/programs/revenue-distribution/tests/sweep_distribution_tokens_test.rs
@@ -118,6 +118,7 @@ async fn test_sweep_distribution_tokens() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(1),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -127,6 +128,9 @@ async fn test_sweep_distribution_tokens() {
         .await
         .unwrap()
         .initialize_distribution(&debt_accountant_signer)
+        .await
+        .unwrap()
+        .warp_timestamp_by(1)
         .await
         .unwrap()
         .configure_distribution_debt(
@@ -218,6 +222,9 @@ async fn test_sweep_distribution_tokens() {
 
     test_setup
         .initialize_distribution(&debt_accountant_signer)
+        .await
+        .unwrap()
+        .warp_timestamp_by(1)
         .await
         .unwrap()
         .configure_distribution_debt(
@@ -343,6 +350,11 @@ async fn test_sweep_distribution_tokens() {
     expected_distribution.collected_2z_converted_from_sol = expected_swept_2z_amount_1;
     expected_distribution.processed_solana_validator_debt_end_index = total_solana_validators / 8;
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp = test_setup
+        .get_clock()
+        .await
+        .unix_timestamp
+        .saturating_sub(1) as u32;
     assert_eq!(distribution, expected_distribution);
 
     assert_eq!(remaining_distribution_data, vec![0b11111011]);
@@ -411,6 +423,8 @@ async fn test_sweep_distribution_tokens() {
     expected_distribution.uncollectible_sol_debt = uncollectible_debt.amount;
     expected_distribution.processed_solana_validator_debt_end_index = total_solana_validators / 8;
     expected_distribution.distribute_rewards_relay_lamports = distribute_rewards_relay_lamports;
+    expected_distribution.calculation_allowed_timestamp =
+        test_setup.get_clock().await.unix_timestamp as u32;
     assert_eq!(distribution, expected_distribution);
 
     assert_eq!(remaining_distribution_data, vec![0b11111111]);

--- a/programs/revenue-distribution/tests/terminate_prepaid_connection_test.rs
+++ b/programs/revenue-distribution/tests/terminate_prepaid_connection_test.rs
@@ -100,6 +100,7 @@ async fn test_terminate_prepaid_connection() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(1),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -139,7 +140,7 @@ async fn test_terminate_prepaid_connection() {
     // Test inputs.
 
     let termination_relayer_key = Pubkey::new_unique();
-    let termination_beneficiary_key = test_setup.payer_signer.pubkey();
+    let termination_beneficiary_key = test_setup.payer_signer().pubkey();
 
     let relayer_balance_before = 128 * 6_960;
 
@@ -157,6 +158,7 @@ async fn test_terminate_prepaid_connection() {
 
     let prepaid_connection_key = PrepaidConnection::find_address(&user_key).0;
     let closed_account = test_setup
+        .context
         .banks_client
         .get_account(prepaid_connection_key)
         .await
@@ -164,6 +166,7 @@ async fn test_terminate_prepaid_connection() {
     assert!(closed_account.is_none());
 
     let relayer_balance_after = test_setup
+        .context
         .banks_client
         .get_balance(termination_relayer_key)
         .await

--- a/programs/revenue-distribution/tests/verify_distribution_merkle_root_test.rs
+++ b/programs/revenue-distribution/tests/verify_distribution_merkle_root_test.rs
@@ -94,6 +94,7 @@ async fn test_verify_distribution_merkle_root() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(1),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
         )
@@ -103,6 +104,9 @@ async fn test_verify_distribution_merkle_root() {
         .await
         .unwrap()
         .initialize_distribution(&debt_accountant_signer)
+        .await
+        .unwrap()
+        .warp_timestamp_by(1)
         .await
         .unwrap()
         .configure_distribution_debt(

--- a/programs/revenue-distribution/tests/withdraw_sol_test.rs
+++ b/programs/revenue-distribution/tests/withdraw_sol_test.rs
@@ -99,6 +99,7 @@ async fn test_withdraw_sol() {
                 ProgramConfiguration::DistributeRewardsRelayLamports(
                     distribute_rewards_relay_lamports,
                 ),
+                ProgramConfiguration::CalculationGracePeriodSeconds(1),
                 ProgramConfiguration::Sol2zSwapProgram(mock_swap_sol_2z::ID),
                 ProgramConfiguration::Flag(ProgramFlagConfiguration::IsPaused(false)),
             ],
@@ -106,6 +107,9 @@ async fn test_withdraw_sol() {
         .await
         .unwrap()
         .initialize_distribution(&benevolent_dictator_signer)
+        .await
+        .unwrap()
+        .warp_timestamp_by(1)
         .await
         .unwrap()
         .configure_distribution_debt(
@@ -167,6 +171,7 @@ async fn test_withdraw_sol() {
     assert_eq!(journal.swap_2z_destination_balance, amount_2z_in);
 
     let sol_destination_balance = test_setup
+        .context
         .banks_client
         .get_balance(sol_destination_key)
         .await


### PR DESCRIPTION
Instead of the calculation grace period being a superficial indicator to offchain accountants to perform calculations, this change enforces the grace period by recording the timestamp when calculations are allowed to be submitted.

This change also restricts the grace period from being set too high (arbitrarily chose 24 hours as the maximum).

Testing needed to change to use the program test context in order to manipulate the Clock sysvar account.

Closes: https://github.com/malbeclabs/doublezero/issues/1561.