### PR TITLE
revenue-distribution: fix Solana validator deposit account creation

### DIFF
--- a/programs/revenue-distribution/src/processor.rs
+++ b/programs/revenue-distribution/src/processor.rs
@@ -2301,6 +2301,11 @@ fn try_initialize_solana_validator_deposit(
     // writable and a signer.
     let (_, payer_info) = try_next_enumerated_account(&mut accounts_iter, Default::default())?;
 
+    // Lamports may have already been transferred to this account before its
+    // creation. We should capture these lamports and add them to the new
+    // account's lamports.
+    let additional_lamports = new_solana_validator_deposit_info.lamports();
+
     try_create_account(
         Invoker::Signer(payer_info.key),
         Invoker::Pda {
@@ -2315,7 +2320,10 @@ fn try_initialize_solana_validator_deposit(
         zero_copy::data_end::<SolanaValidatorDeposit>(),
         &ID,
         accounts,
-        Default::default(),
+        CreateAccountOptions {
+            rent_sysvar: None,
+            additional_lamports: Some(additional_lamports),
+        },
     )?;
 
     // Finally, initialize the solana validator deposit with the node id.

--- a/programs/revenue-distribution/tests/pay_solana_validator_debt_test.rs
+++ b/programs/revenue-distribution/tests/pay_solana_validator_debt_test.rs
@@ -237,7 +237,7 @@ async fn test_pay_solana_validator_debt() {
             .unwrap();
 
         // Balance must include rent.
-        // assert_eq!(balance, amount + deposit_rent_exemption);
+        assert_eq!(balance, amount + deposit_rent_exemption);
 
         // Store balance before paying debt.
         *balance_before = balance;


### PR DESCRIPTION
This change ensures that any lamports transferred to a Solana validator deposit account are not counted towards the rent exemption amount when it is created.

Closes https://github.com/malbeclabs/doublezero/issues/1592.