### PR TITLE
mock/swap-sol-2z: change program ID

### DIFF
--- a/mock/swap-sol-2z/src/lib.rs
+++ b/mock/swap-sol-2z/src/lib.rs
@@ -5,4 +5,4 @@ pub mod state;
 
 //
 
-solana_pubkey::declare_id!("MockSwapSo12Z111111111111111111111111111111");
+solana_pubkey::declare_id!("ms2ZZhUaXgFW6PQBHK1hxjg1fn8mZejm4zUCtQvHqU2");


### PR DESCRIPTION
In order to deploy this program to Solana testnet, I needed to change the program ID to one belonging to a randomly generated keypair.

Closes https://github.com/malbeclabs/doublezero/issues/1623.