### PR TITLE
disallow cpi with instructions requiring sentinel observation

### DIFF
--- a/programs/passport/Cargo.toml
+++ b/programs/passport/Cargo.toml
@@ -12,7 +12,7 @@ borsh = { workspace = true, features = ["derive"] }
 bytemuck = { workspace = true, features = ["derive", "min_const_generics"] }
 doublezero-program-tools = { workspace = true, features = ["entrypoint"] }
 solana-account-info.workspace = true
-solana-instruction.workspace = true
+solana-instruction = { workspace = true, features = ["syscalls"] }
 solana-msg.workspace = true
 solana-program-entrypoint.workspace = true
 solana-program-error.workspace = true

--- a/programs/passport/src/processor.rs
+++ b/programs/passport/src/processor.rs
@@ -11,6 +11,7 @@ use doublezero_program_tools::{
     zero_copy::{self, ZeroCopyAccount, ZeroCopyMutAccount},
 };
 use solana_account_info::AccountInfo;
+use solana_instruction::{syscalls::get_stack_height, TRANSACTION_LEVEL_STACK_HEIGHT};
 use solana_msg::msg;
 use solana_program_error::{ProgramError, ProgramResult};
 use solana_pubkey::Pubkey;
@@ -179,6 +180,11 @@ fn try_configure_program(accounts: &[AccountInfo], setting: ProgramConfiguration
 
 fn try_request_access(accounts: &[AccountInfo], access_mode: AccessMode) -> ProgramResult {
     msg!("Request access");
+
+    if get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {
+        msg!("Cannot CPI request access");
+        return Err(ProgramError::InvalidInstructionData);
+    }
 
     let AccessMode::SolanaValidator { service_key, .. } = access_mode;
 

--- a/programs/revenue-distribution/src/processor.rs
+++ b/programs/revenue-distribution/src/processor.rs
@@ -14,6 +14,7 @@ use doublezero_program_tools::{
 };
 use solana_account_info::AccountInfo;
 use solana_cpi::invoke_signed_unchecked;
+use solana_instruction::{syscalls::get_stack_height, TRANSACTION_LEVEL_STACK_HEIGHT};
 use solana_msg::msg;
 use solana_program_error::{ProgramError, ProgramResult};
 use solana_pubkey::Pubkey;
@@ -1458,6 +1459,11 @@ fn try_initialize_prepaid_connection(
     decimals: u8,
 ) -> ProgramResult {
     msg!("Initialize prepaid connection");
+
+    if get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {
+        msg!("Cannot CPI initialize prepaid connection");
+        return Err(ProgramError::InvalidInstructionData);
+    }
 
     if user_key == Pubkey::default() {
         msg!("User key cannot be zero address");


### PR DESCRIPTION
Both request-access in Passport and initialize-prepaid-connection in Revenue Distribution will require a Sentinel to observe these instructions being invoked. But there are no plans to read them from inner instructions.

Closes https://github.com/malbeclabs/doublezero/issues/1645.