### PR TITLE
client-tools: fix tracing log macros

### DIFF
--- a/crates/client-tools/src/log.rs
+++ b/crates/client-tools/src/log.rs
@@ -1,55 +1,63 @@
+#[cfg(feature = "tracing")]
 #[macro_export]
 macro_rules! log_info {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
-        {
-            ::tracing::info!($($arg)*);
-        }
-        #[cfg(not(feature = "tracing"))]
-        {
-            println!($($arg)*);
-        }
+        ::tracing::info!($($arg)*);
     };
 }
 
+#[cfg(not(feature = "tracing"))]
+#[macro_export]
+macro_rules! log_info {
+    ($($arg:tt)*) => {
+        println!($($arg)*);
+    };
+}
+
+#[cfg(feature = "tracing")]
 #[macro_export]
 macro_rules! log_error {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
-        {
-            ::tracing::error!($($arg)*);
-        }
-        #[cfg(not(feature = "tracing"))]
-        {
-            eprintln!($($arg)*);
-        }
+        ::tracing::error!($($arg)*);
     };
 }
 
+#[cfg(not(feature = "tracing"))]
+#[macro_export]
+macro_rules! log_error {
+    ($($arg:tt)*) => {
+        eprintln!($($arg)*);
+    };
+}
+
+#[cfg(feature = "tracing")]
 #[macro_export]
 macro_rules! log_warn {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
-        {
-            ::tracing::warn!($($arg)*);
-        }
-        #[cfg(not(feature = "tracing"))]
-        {
-            eprintln!($($arg)*);
-        }
+        ::tracing::warn!($($arg)*);
     };
 }
 
+#[cfg(not(feature = "tracing"))]
+#[macro_export]
+macro_rules! log_warn {
+    ($($arg:tt)*) => {
+        eprintln!($($arg)*);
+    };
+}
+
+#[cfg(feature = "tracing")]
 #[macro_export]
 macro_rules! log_debug {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
-        {
-            ::tracing::debug!($($arg)*);
-        }
-        #[cfg(not(feature = "tracing"))]
-        {
-            println!($($arg)*);
-        }
+        ::tracing::debug!($($arg)*);
+    };
+}
+
+#[cfg(not(feature = "tracing"))]
+#[macro_export]
+macro_rules! log_debug {
+    ($($arg:tt)*) => {
+        println!($($arg)*);
     };
 }


### PR DESCRIPTION
By defining `cfg(feature="tracing")` inside the macro itself, the cfg is used in the context of the crate using the macro (and not the defining crate). This PR fixes the issue.