### PR TITLE
passport: enhance access request logging with access mode details

### DIFF
--- a/programs/passport/src/processor.rs
+++ b/programs/passport/src/processor.rs
@@ -195,7 +195,7 @@ fn try_configure_program(accounts: &[AccountInfo], setting: ProgramConfiguration
 }
 
 fn try_request_access(accounts: &[AccountInfo], access_mode: AccessMode) -> ProgramResult {
-    msg!("Request access");
+    msg!("Request access: {:?}", access_mode);
 
     if get_stack_height() != TRANSACTION_LEVEL_STACK_HEIGHT {
         msg!("Cannot CPI request access");


### PR DESCRIPTION
This pull request makes a minor improvement to the logging in the `try_request_access` function. The log message now includes the value of `access_mode`, which will help with debugging and tracing access requests.

* Improved debug logging in `try_request_access` to include `access_mode` value.