### PR TITLE
revenue-distribution: next_dz_epoch -> next_completed_dz_epoch

### DIFF
--- a/programs/revenue-distribution/src/instruction/account.rs
+++ b/programs/revenue-distribution/src/instruction/account.rs
@@ -693,13 +693,13 @@ impl ForgiveSolanaValidatorDebtAccounts {
     pub fn new(
         debt_accountant_key: &Pubkey,
         dz_epoch: DoubleZeroEpoch,
-        next_completed_dz_epoch: DoubleZeroEpoch,
+        next_dz_epoch: DoubleZeroEpoch,
     ) -> Self {
         Self {
             program_config_key: ProgramConfig::find_address().0,
             debt_accountant_key: *debt_accountant_key,
             distribution_key: Distribution::find_address(dz_epoch).0,
-            next_distribution_key: Distribution::find_address(next_completed_dz_epoch).0,
+            next_distribution_key: Distribution::find_address(next_dz_epoch).0,
         }
     }
 }

--- a/programs/revenue-distribution/tests/common/mod.rs
+++ b/programs/revenue-distribution/tests/common/mod.rs
@@ -797,7 +797,7 @@ impl ProgramTestWithOwner {
     pub async fn forgive_solana_validator_debt(
         &mut self,
         dz_epoch: DoubleZeroEpoch,
-        next_completed_dz_epoch: DoubleZeroEpoch,
+        next_dz_epoch: DoubleZeroEpoch,
         debt_accountant_signer: &Keypair,
         debt: &SolanaValidatorDebt,
         proof: MerkleProof,
@@ -809,7 +809,7 @@ impl ProgramTestWithOwner {
             ForgiveSolanaValidatorDebtAccounts::new(
                 &debt_accountant_signer.pubkey(),
                 dz_epoch,
-                next_completed_dz_epoch,
+                next_dz_epoch,
             ),
             &RevenueDistributionInstructionData::ForgiveSolanaValidatorDebt { debt: *debt, proof },
         )

--- a/programs/revenue-distribution/tests/distribute_rewards_test.rs
+++ b/programs/revenue-distribution/tests/distribute_rewards_test.rs
@@ -57,7 +57,7 @@ async fn test_distribute_rewards() {
     // Distribution debt.
 
     let dz_epoch = DoubleZeroEpoch::new(1);
-    let next_completed_dz_epoch = dz_epoch.saturating_add_duration(1);
+    let next_dz_epoch = dz_epoch.saturating_add_duration(1);
 
     let debt_data = (0..8)
         .map(|i| SolanaValidatorDebt {
@@ -168,7 +168,7 @@ async fn test_distribute_rewards() {
         .await
         .unwrap()
         .configure_distribution_debt(
-            next_completed_dz_epoch,
+            next_dz_epoch,
             &debt_accountant_signer,
             total_solana_validators,
             total_solana_validator_debt,
@@ -176,7 +176,7 @@ async fn test_distribute_rewards() {
         )
         .await
         .unwrap()
-        .finalize_distribution_debt(next_completed_dz_epoch, &debt_accountant_signer)
+        .finalize_distribution_debt(next_dz_epoch, &debt_accountant_signer)
         .await
         .unwrap();
 
@@ -205,12 +205,12 @@ async fn test_distribute_rewards() {
                 .transfer_lamports(&deposit_key, amount)
                 .await
                 .unwrap()
-                .pay_solana_validator_debt(next_completed_dz_epoch, node_id, amount, proof.clone())
+                .pay_solana_validator_debt(next_dz_epoch, node_id, amount, proof.clone())
                 .await
                 .unwrap()
                 .forgive_solana_validator_debt(
                     dz_epoch,
-                    next_completed_dz_epoch,
+                    next_dz_epoch,
                     &debt_accountant_signer,
                     &uncollectible_debt,
                     proof,
@@ -228,7 +228,7 @@ async fn test_distribute_rewards() {
                 .pay_solana_validator_debt(dz_epoch, node_id, amount, proof.clone())
                 .await
                 .unwrap()
-                .pay_solana_validator_debt(next_completed_dz_epoch, node_id, amount, proof)
+                .pay_solana_validator_debt(next_dz_epoch, node_id, amount, proof)
                 .await
                 .unwrap();
         }
@@ -261,7 +261,7 @@ async fn test_distribute_rewards() {
         .sweep_distribution_tokens(dz_epoch)
         .await
         .unwrap()
-        .sweep_distribution_tokens(next_completed_dz_epoch)
+        .sweep_distribution_tokens(next_dz_epoch)
         .await
         .unwrap();
 
@@ -389,7 +389,7 @@ async fn test_distribute_rewards() {
         .await
         .unwrap()
         .configure_distribution_rewards(
-            next_completed_dz_epoch,
+            next_dz_epoch,
             &rewards_accountant_signer,
             total_contributors,
             rewards_merkle_root,
@@ -415,10 +415,10 @@ async fn test_distribute_rewards() {
         .finalize_distribution_rewards(dz_epoch)
         .await
         .unwrap()
-        .verify_distribution_merkle_root(next_completed_dz_epoch, kinds_and_proofs)
+        .verify_distribution_merkle_root(next_dz_epoch, kinds_and_proofs)
         .await
         .unwrap()
-        .finalize_distribution_rewards(next_completed_dz_epoch)
+        .finalize_distribution_rewards(next_dz_epoch)
         .await
         .unwrap();
 
@@ -455,7 +455,7 @@ async fn test_distribute_rewards() {
         // Distribute for the second epoch.
         test_setup
             .distribute_rewards(
-                next_completed_dz_epoch,
+                next_dz_epoch,
                 &share,
                 &DOUBLEZERO_MINT_KEY,
                 &relayer_key,
@@ -557,16 +557,16 @@ async fn test_distribute_rewards() {
         remaining_distribution_data,
         distribution_lamports,
         distribution_2z_token_pda,
-    ) = test_setup.fetch_distribution(next_completed_dz_epoch).await;
+    ) = test_setup.fetch_distribution(next_dz_epoch).await;
 
     let mut expected_distribution = Distribution::default();
     expected_distribution.set_is_debt_calculation_finalized(true);
     expected_distribution.set_is_rewards_calculation_finalized(true);
     expected_distribution.set_has_swept_2z_tokens(true);
-    expected_distribution.bump_seed = Distribution::find_address(next_completed_dz_epoch).1;
+    expected_distribution.bump_seed = Distribution::find_address(next_dz_epoch).1;
     expected_distribution.token_2z_pda_bump_seed =
         state::find_2z_token_pda_address(&distribution_key).1;
-    expected_distribution.dz_epoch = next_completed_dz_epoch;
+    expected_distribution.dz_epoch = next_dz_epoch;
     expected_distribution.community_burn_rate = BurnRate::new(initial_cbr).unwrap();
     expected_distribution
         .solana_validator_fee_parameters

--- a/programs/revenue-distribution/tests/forgive_solana_validator_debt_test.rs
+++ b/programs/revenue-distribution/tests/forgive_solana_validator_debt_test.rs
@@ -45,7 +45,7 @@ async fn test_forgive_solana_validator_debt() {
     let distribute_rewards_relay_lamports = 10_000;
 
     let dz_epoch = DoubleZeroEpoch::new(1);
-    let next_completed_dz_epoch = dz_epoch.saturating_add_duration(1);
+    let next_dz_epoch = dz_epoch.saturating_add_duration(1);
 
     // Distribution debt accounting.
 
@@ -129,7 +129,7 @@ async fn test_forgive_solana_validator_debt() {
         .await
         .unwrap()
         .configure_distribution_debt(
-            next_completed_dz_epoch,
+            next_dz_epoch,
             &debt_accountant_signer,
             total_solana_validators,
             total_solana_validator_debt,
@@ -154,7 +154,7 @@ async fn test_forgive_solana_validator_debt() {
         ForgiveSolanaValidatorDebtAccounts::new(
             &debt_accountant_signer.pubkey(),
             dz_epoch,
-            next_completed_dz_epoch,
+            next_dz_epoch,
         ),
         &RevenueDistributionInstructionData::ForgiveSolanaValidatorDebt {
             debt,
@@ -203,11 +203,11 @@ async fn test_forgive_solana_validator_debt() {
     );
     assert_eq!(
         program_logs.get(5).unwrap(),
-        &format!("Program log: Next epoch {next_completed_dz_epoch} has unfinalized debt")
+        &format!("Program log: Next epoch {next_dz_epoch} has unfinalized debt")
     );
 
     test_setup
-        .finalize_distribution_debt(next_completed_dz_epoch, &debt_accountant_signer)
+        .finalize_distribution_debt(next_dz_epoch, &debt_accountant_signer)
         .await
         .unwrap();
 
@@ -282,7 +282,7 @@ async fn test_forgive_solana_validator_debt() {
         test_setup
             .forgive_solana_validator_debt(
                 dz_epoch,
-                next_completed_dz_epoch,
+                next_dz_epoch,
                 &debt_accountant_signer,
                 debt,
                 proof,
@@ -322,14 +322,14 @@ async fn test_forgive_solana_validator_debt() {
     assert_eq!(remaining_distribution_data, vec![0b11111111, 0b11111111]);
 
     let (distribution_key, distribution, remaining_distribution_data, _, _) =
-        test_setup.fetch_distribution(next_completed_dz_epoch).await;
+        test_setup.fetch_distribution(next_dz_epoch).await;
 
     let mut expected_distribution = Distribution::default();
     expected_distribution.set_is_debt_calculation_finalized(true);
-    expected_distribution.bump_seed = Distribution::find_address(next_completed_dz_epoch).1;
+    expected_distribution.bump_seed = Distribution::find_address(next_dz_epoch).1;
     expected_distribution.token_2z_pda_bump_seed =
         state::find_2z_token_pda_address(&distribution_key).1;
-    expected_distribution.dz_epoch = next_completed_dz_epoch;
+    expected_distribution.dz_epoch = next_dz_epoch;
     expected_distribution.community_burn_rate = BurnRate::new(initial_cbr).unwrap();
     expected_distribution
         .solana_validator_fee_parameters
@@ -367,7 +367,7 @@ async fn test_forgive_solana_validator_debt() {
             ForgiveSolanaValidatorDebtAccounts::new(
                 &debt_accountant_signer.pubkey(),
                 dz_epoch,
-                next_completed_dz_epoch,
+                next_dz_epoch,
             ),
             &RevenueDistributionInstructionData::ForgiveSolanaValidatorDebt { debt: *debt, proof },
         )

--- a/programs/revenue-distribution/tests/sweep_distribution_tokens_test.rs
+++ b/programs/revenue-distribution/tests/sweep_distribution_tokens_test.rs
@@ -255,7 +255,7 @@ async fn test_sweep_distribution_tokens() {
     // Initialize another distribution. Out of convenience, use the same debt
     // calculations.
 
-    let next_completed_dz_epoch = dz_epoch.saturating_add_duration(1);
+    let next_dz_epoch = dz_epoch.saturating_add_duration(1);
 
     test_setup
         .initialize_distribution(&debt_accountant_signer)
@@ -265,7 +265,7 @@ async fn test_sweep_distribution_tokens() {
         .await
         .unwrap()
         .configure_distribution_debt(
-            next_completed_dz_epoch,
+            next_dz_epoch,
             &debt_accountant_signer,
             total_solana_validators,
             total_solana_validator_debt,
@@ -273,7 +273,7 @@ async fn test_sweep_distribution_tokens() {
         )
         .await
         .unwrap()
-        .finalize_distribution_debt(next_completed_dz_epoch, &debt_accountant_signer)
+        .finalize_distribution_debt(next_dz_epoch, &debt_accountant_signer)
         .await
         .unwrap();
 
@@ -296,7 +296,7 @@ async fn test_sweep_distribution_tokens() {
             .transfer_lamports(&deposit_key, amount)
             .await
             .unwrap()
-            .pay_solana_validator_debt(next_completed_dz_epoch, node_id, amount, proof)
+            .pay_solana_validator_debt(next_dz_epoch, node_id, amount, proof)
             .await
             .unwrap();
     }
@@ -407,7 +407,7 @@ async fn test_sweep_distribution_tokens() {
     test_setup
         .forgive_solana_validator_debt(
             dz_epoch,
-            next_completed_dz_epoch,
+            next_dz_epoch,
             &debt_accountant_signer,
             &uncollectible_debt,
             proof,
@@ -417,7 +417,7 @@ async fn test_sweep_distribution_tokens() {
 
     // Sweep next distribution.
     test_setup
-        .sweep_distribution_tokens(next_completed_dz_epoch)
+        .sweep_distribution_tokens(next_dz_epoch)
         .await
         .unwrap();
 
@@ -437,15 +437,15 @@ async fn test_sweep_distribution_tokens() {
         remaining_distribution_data,
         _,
         _distribution_2z_token_pda,
-    ) = test_setup.fetch_distribution(next_completed_dz_epoch).await;
+    ) = test_setup.fetch_distribution(next_dz_epoch).await;
 
     let mut expected_distribution = Distribution::default();
     expected_distribution.set_is_debt_calculation_finalized(true);
     expected_distribution.set_has_swept_2z_tokens(true);
-    expected_distribution.bump_seed = Distribution::find_address(next_completed_dz_epoch).1;
+    expected_distribution.bump_seed = Distribution::find_address(next_dz_epoch).1;
     expected_distribution.token_2z_pda_bump_seed =
         state::find_2z_token_pda_address(&distribution_key).1;
-    expected_distribution.dz_epoch = next_completed_dz_epoch;
+    expected_distribution.dz_epoch = next_dz_epoch;
     expected_distribution.community_burn_rate = BurnRate::new(initial_cbr).unwrap();
     expected_distribution
         .solana_validator_fee_parameters


### PR DESCRIPTION
Next DZ epoch in the program config can cause confusion in understanding what this means with respect to the epoch on DoubleZero Ledger network. This name change makes this field more explicit to reflect that the next completed DoubleZero epoch will be X.

Closes https://github.com/malbeclabs/doublezero/issues/1809.