### PR TITLE
revenue-distribution: validate destination authority in WithdrawIntegrationRewards handler

### DIFF
--- a/programs/revenue-distribution/CHANGELOG.md
+++ b/programs/revenue-distribution/CHANGELOG.md
@@ -7,6 +7,7 @@
 - scaffold integration harvesting (#115)
 - collect integration rewards (#116)
 - track collected integrations via inline bitmap on distribution (#117)
+- validate destination authority in withdraw integration rewards handler (#119)
 
 ## [v0.3.4]
 - withdraw deposited SOL (#111)

--- a/programs/revenue-distribution/src/integration.rs
+++ b/programs/revenue-distribution/src/integration.rs
@@ -12,6 +12,7 @@ use solana_account_info::AccountInfo;
 use solana_instruction::AccountMeta;
 use solana_msg::msg;
 use solana_program_error::ProgramError;
+use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 
 use crate::state::Distribution;
@@ -118,9 +119,11 @@ impl From<WithdrawIntegrationRewardsAccounts> for Vec<AccountMeta> {
 
 /// Handler-side view of [`WithdrawIntegrationRewardsAccounts`]. Integration
 /// programs peel this out of their `accounts_iter` in one call, which
-/// enforces the slot ordering, contract-level writable/signer flags, and
-/// that the parent `Distribution`'s `dz_epoch` matches the integration's
-/// local epoch.
+/// enforces the slot ordering, contract-level writable/signer flags, that
+/// the parent `Distribution`'s `dz_epoch` matches the integration's local
+/// epoch, and that the destination token account's authority is the parent
+/// `Distribution` (so the bucket can only flow back to a token account the
+/// parent controls).
 pub struct WithdrawIntegrationRewardsHandlerAccounts<'a, 'b> {
     pub integration_distribution_info: (usize, &'a AccountInfo<'b>),
     pub integration_2z_bucket_info: (usize, &'a AccountInfo<'b>),
@@ -167,6 +170,17 @@ impl<'a, 'b> TryNextAccounts<'a, 'b, crate::types::DoubleZeroEpoch>
                 "DZ epoch mismatch: integration={}, parent={}",
                 integration_dz_epoch,
                 parent_distribution.dz_epoch,
+            );
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let destination_token_account = spl_token_interface::state::Account::unpack(
+            &destination_token_account_info.1.data.borrow()[..],
+        )?;
+        if destination_token_account.owner != *parent_distribution.info.key {
+            msg!(
+                "Destination token account (account {}) authority must be parent distribution",
+                destination_token_account_info.0,
             );
             return Err(ProgramError::InvalidAccountData);
         }


### PR DESCRIPTION
Resolves: malbeclabs/infra#1118

## Summary
- Addresses a review comment on doublezero-shreds#340: the integration-side helper `WithdrawIntegrationRewardsHandlerAccounts::try_next_accounts` previously handed the destination token account to integration programs unvalidated. An integration that trusted the helper could be pointed at any token account.
- Now unpacks the destination as an SPL token account and rejects unless its `owner` (authority) equals the parent `Distribution`'s pubkey. Safe because the helper already verifies `parent_distribution` is a rev-distr-owned PDA and a signer, so the comparison is meaningful — the bucket can only flow back to a token account the parent controls.
- Defense-in-depth: rev-distr's own `CollectIntegrationRewards` already pins the destination to `find_2z_token_pda_address(distribution_key)`, but every integration consuming this helper now inherits the same invariant without having to re-derive it.

## Lines of Code
| Section | Added | Removed |
|---------|-------|---------|
| Core logic | +17 | -3 |
| SDKs | 0 | 0 |
| Tests | 0 | 0 |